### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "numpy>=1.23.5,<2",
     "pandas>=2.2.1",
     "pint<=0.21",
+    "py7zr<=1.0.0rc1",
     "pyperclip",
     "pyside6",
     "pypardiso ; platform_system == 'Windows'",


### PR DESCRIPTION
Breaking change between py7zr==1.0.0rc1 and rc3 (the most recent, installed by default).

**Problem:**
Cannot import ecoinvent to memory (biosphere to disk worked fine)

**Cause:**
`ecoinvent_importer.py` function `read_archive_to_bytes` attempts `archive.read(file_list)`. This attribute was removed in rc2 of py7zr.

**Workaround (in this pr):**
pin dependency to "py7zr<=1.0.0rc1"

**Solution (not in this pr):**
work out how to implement the new method with the 'factory' argument 

**See relevant section of py7zr changelog here:**

> 
> Incompatible change
> 
> There is incompatible change between v1.0.0-rc1 to v1.0.0-rc2.
> I abandon methods ``read`` and ``readall``.
> When you want to extract the archive to memory, you need to use
> ``extract`` method with ``factory`` argument. The ``factory`` takes a factory class, as of the GoF design pattern,
> that provides object implements ``Py7zIO`` interface as a call back instance.
> ``SevenZipFile`` extract and write uncompressed data into your ``Py7zIO`` object.
> 

**See error message here:**

> Wrote 633 LCIA methods with 481813 characterization factors
> 13:31:54 | INFO | Extracting .7z archive to memory
> Error calling Python override of QThread::run(): 13:31:54 | ERROR | AttributeError: 'SevenZipFile' object has no attribute 'read'
> Traceback (most recent call last):
>   File "/media/stew/s2-ssd-data/code/gh/activity-browser/activity_browser/ui/threading.py", line 43, in run
>     raise e
>   File "/media/stew/s2-ssd-data/code/gh/activity-browser/activity_browser/ui/threading.py", line 39, in run
>     self.run_safely(*self._args, **self._kwargs)
>   File "/media/stew/s2-ssd-data/code/gh/activity-browser/activity_browser/actions/database/database_import_from_ecoinvent.py", line 420, in run_safely
>     importer.install_ecoinvent(database_name, biosphere_name)
>   File "/media/stew/s2-ssd-data/code/gh/activity-browser/activity_browser/bwutils/io/ecoinvent_importer.py", line 75, in install_ecoinvent
>     spold_bytes = self.read_archive_to_bytes()
>                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/media/stew/s2-ssd-data/code/gh/activity-browser/activity_browser/bwutils/io/ecoinvent_importer.py", line 126, in read_archive_to_bytes
>     extracted_data = archive.read(file_list)
>                      ^^^^^^^^^^^^
> AttributeError: 'SevenZipFile' object has no attribute 'read'
> 13:35:14 | INFO | Extracting .7z archive to memory
> Error calling Python override of QThread::run(): 13:35:14 | ERROR | AttributeError: 'SevenZipFile' object has no attribute 'read'
> Traceback (most recent call last):
>   File "/media/stew/s2-ssd-data/code/gh/activity-browser/activity_browser/ui/threading.py", line 43, in run
>     raise e
>   File "/media/stew/s2-ssd-data/code/gh/activity-browser/activity_browser/ui/threading.py", line 39, in run
>     self.run_safely(*self._args, **self._kwargs)
>   File "/media/stew/s2-ssd-data/code/gh/activity-browser/activity_browser/actions/database/database_import_from_ecoinvent.py", line 420, in run_safely
>     importer.install_ecoinvent(database_name, biosphere_name)
>   File "/media/stew/s2-ssd-data/code/gh/activity-browser/activity_browser/bwutils/io/ecoinvent_importer.py", line 75, in install_ecoinvent
>     spold_bytes = self.read_archive_to_bytes()
>                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/media/stew/s2-ssd-data/code/gh/activity-browser/activity_browser/bwutils/io/ecoinvent_importer.py", line 126, in read_archive_to_bytes
>     all_files = archive.readall()
>                      ^^^^^^^^^^^^
> AttributeError: 'SevenZipFile' object has no attribute 'read'


**See successful output here (after running `pip install py7zr==1.0.0rc1`):**

> 15:07:38 | INFO | Extracting .7z archive to memory
> 15:07:58 | INFO | Extracting XML data from 25412 datasets
